### PR TITLE
feat: improve inference ergonomics and evaluation

### DIFF
--- a/src/gpt/attention.py
+++ b/src/gpt/attention.py
@@ -7,6 +7,8 @@ import math
 import torch
 from torch import Tensor, nn
 
+LayerCache = tuple[Tensor, Tensor]
+
 
 def causal_mask(sequence_length: int, device: torch.device) -> Tensor:
     return torch.tril(torch.ones(sequence_length, sequence_length, device=device, dtype=torch.bool))
@@ -90,6 +92,37 @@ class MultiHeadCausalSelfAttention(nn.Module):
 
     def forward(self, x: Tensor) -> Tensor:
         return self.inspect(x)["output"]
+
+    def forward_with_cache(
+        self,
+        x: Tensor,
+        cache: LayerCache | None = None,
+    ) -> tuple[Tensor, LayerCache]:
+        if x.ndim != 3:
+            msg = "x must have shape (batch_size, sequence_length, n_embd)"
+            raise ValueError(msg)
+        if x.size(1) != 1:
+            msg = "forward_with_cache expects a single new token with shape (batch_size, 1, n_embd)"
+            raise ValueError(msg)
+
+        q = self._split_heads(self.query(x))
+        k_new = self._split_heads(self.key(x))
+        v_new = self._split_heads(self.value(x))
+
+        if cache is None:
+            k_all = k_new
+            v_all = v_new
+        else:
+            past_k, past_v = cache
+            k_all = torch.cat((past_k, k_new), dim=2)
+            v_all = torch.cat((past_v, v_new), dim=2)
+
+        scale = 1.0 / math.sqrt(self.head_dim)
+        scores = torch.matmul(q, k_all.transpose(-2, -1)) * scale
+        attention_weights = torch.softmax(scores, dim=-1)
+        head_outputs = torch.matmul(attention_weights, v_all)
+        merged = self._merge_heads(head_outputs)
+        return self.proj(merged), (k_all, v_all)
 
     def inspect(self, x: Tensor) -> dict[str, Tensor]:
         if x.ndim != 3:

--- a/src/gpt/blocks.py
+++ b/src/gpt/blocks.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import torch
 from torch import Tensor, nn
 
-from .attention import MultiHeadCausalSelfAttention
+from .attention import LayerCache, MultiHeadCausalSelfAttention
 
 
 class RMSNorm(nn.Module):
@@ -53,3 +53,16 @@ class TransformerBlock(nn.Module):
         x = x + self.attention(self.attention_norm(x))
         x = x + self.feed_forward(self.feed_forward_norm(x))
         return x
+
+    def forward_with_cache(
+        self,
+        x: Tensor,
+        cache: LayerCache | None = None,
+    ) -> tuple[Tensor, LayerCache]:
+        attention_out, next_cache = self.attention.forward_with_cache(
+            self.attention_norm(x),
+            cache=cache,
+        )
+        x = x + attention_out
+        x = x + self.feed_forward(self.feed_forward_norm(x))
+        return x, next_cache

--- a/src/gpt/cli.py
+++ b/src/gpt/cli.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 from .checkpoint import load_checkpoint, save_checkpoint
 from .data.download import dataset_path, download_names_dataset
-from .dataset import load_documents
+from .dataset import build_token_stream, load_documents
+from .evaluation import evaluate_model, split_token_stream
 from .generation import generate_text
 from .training import TrainingConfig, train_model
 
@@ -44,6 +45,8 @@ def build_parser() -> ArgumentParser:
     train_parser.add_argument("--prompt", default="a")
     train_parser.add_argument("--max-new-tokens", type=int, default=24)
     train_parser.add_argument("--temperature", type=float, default=1.0)
+    train_parser.add_argument("--top-k", type=int)
+    train_parser.add_argument("--no-kv-cache", action="store_true")
     train_parser.add_argument("--checkpoint-out", type=Path)
 
     generate_parser = subparsers.add_parser(
@@ -54,6 +57,18 @@ def build_parser() -> ArgumentParser:
     generate_parser.add_argument("--prompt", default="")
     generate_parser.add_argument("--max-new-tokens", type=int, default=24)
     generate_parser.add_argument("--temperature", type=float, default=1.0)
+    generate_parser.add_argument("--top-k", type=int)
+    generate_parser.add_argument("--no-kv-cache", action="store_true")
+
+    evaluate_parser = subparsers.add_parser(
+        "evaluate",
+        help="Load a checkpoint and report validation loss and perplexity.",
+    )
+    evaluate_parser.add_argument("checkpoint", type=Path)
+    evaluate_parser.add_argument("--dataset", type=Path, default=dataset_path())
+    evaluate_parser.add_argument("--batch-size", type=int, default=32)
+    evaluate_parser.add_argument("--num-batches", type=int, default=20)
+    evaluate_parser.add_argument("--validation-fraction", type=float, default=0.1)
     return parser
 
 
@@ -92,6 +107,8 @@ def main(argv: Sequence[str] | None = None) -> None:
             prompt=args.prompt,
             max_new_tokens=args.max_new_tokens,
             temperature=args.temperature,
+            top_k=args.top_k,
+            use_kv_cache=not args.no_kv_cache,
         )
         print(f"final_loss={artifacts.losses[-1]:.4f}")
         print(f"sample={sample}")
@@ -107,5 +124,26 @@ def main(argv: Sequence[str] | None = None) -> None:
             prompt=args.prompt,
             max_new_tokens=args.max_new_tokens,
             temperature=args.temperature,
+            top_k=args.top_k,
+            use_kv_cache=not args.no_kv_cache,
         )
         print(sample)
+        return
+
+    if args.command == "evaluate":
+        model, tokenizer, training_config = load_checkpoint(args.checkpoint)
+        documents = load_documents(args.dataset)
+        token_stream = build_token_stream(documents, tokenizer)
+        _, validation_stream = split_token_stream(
+            token_stream,
+            validation_fraction=args.validation_fraction,
+        )
+        metrics = evaluate_model(
+            model,
+            validation_stream,
+            batch_size=args.batch_size,
+            block_size=int(training_config["block_size"]),
+            num_batches=args.num_batches,
+        )
+        print(f"validation_loss={metrics.loss:.4f}")
+        print(f"perplexity={metrics.perplexity:.4f}")

--- a/src/gpt/embeddings.py
+++ b/src/gpt/embeddings.py
@@ -16,20 +16,28 @@ class GPTInputEmbedding(nn.Module):
         self.token_embedding = nn.Embedding(vocab_size, n_embd)
         self.position_embedding = nn.Embedding(block_size, n_embd)
 
-    def forward(self, token_ids: Tensor) -> Tensor:
+    def embed_with_positions(self, token_ids: Tensor, *, position_offset: int = 0) -> Tensor:
         if token_ids.ndim != 2:
             msg = "token_ids must have shape (batch_size, sequence_length)"
             raise ValueError(msg)
 
         _, sequence_length = token_ids.shape
-        if sequence_length > self.block_size:
+        end_position = position_offset + sequence_length
+        if end_position > self.block_size:
             msg = f"sequence_length must be <= block_size ({self.block_size})"
             raise ValueError(msg)
 
-        position_ids = torch.arange(sequence_length, device=token_ids.device)
+        position_ids = torch.arange(
+            position_offset,
+            end_position,
+            device=token_ids.device,
+        )
         token_embeddings = self.token_embedding(token_ids)
         position_embeddings = self.position_embedding(position_ids).unsqueeze(0)
         return token_embeddings + position_embeddings
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        return self.embed_with_positions(token_ids)
 
     @property
     def num_parameters(self) -> int:

--- a/src/gpt/evaluation.py
+++ b/src/gpt/evaluation.py
@@ -1,0 +1,54 @@
+"""Lightweight evaluation utilities."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+from .dataset import sample_next_token_batch
+from .gpt import GPT
+from .training import compute_loss
+
+
+@dataclass(frozen=True)
+class EvaluationMetrics:
+    loss: float
+    perplexity: float
+
+
+def split_token_stream(
+    token_stream: torch.Tensor,
+    *,
+    validation_fraction: float = 0.1,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not 0 < validation_fraction < 1:
+        msg = "validation_fraction must be between 0 and 1"
+        raise ValueError(msg)
+    split_index = max(2, int(token_stream.size(0) * (1 - validation_fraction)))
+    return token_stream[:split_index], token_stream[split_index:]
+
+
+@torch.no_grad()
+def evaluate_model(
+    model: GPT,
+    token_stream: torch.Tensor,
+    *,
+    batch_size: int,
+    block_size: int,
+    num_batches: int = 20,
+) -> EvaluationMetrics:
+    model.eval()
+    losses: list[float] = []
+    for _ in range(num_batches):
+        x, y = sample_next_token_batch(
+            token_stream,
+            batch_size=batch_size,
+            block_size=block_size,
+        )
+        logits = model(x)
+        losses.append(compute_loss(logits, y).item())
+
+    loss = sum(losses) / len(losses)
+    return EvaluationMetrics(loss=loss, perplexity=math.exp(loss))

--- a/src/gpt/generation.py
+++ b/src/gpt/generation.py
@@ -15,6 +15,8 @@ def generate_text(
     prompt: str = "",
     max_new_tokens: int = 32,
     temperature: float = 1.0,
+    top_k: int | None = None,
+    use_kv_cache: bool = True,
 ) -> str:
     model.eval()
 
@@ -28,6 +30,8 @@ def generate_text(
         x,
         max_new_tokens=max_new_tokens,
         temperature=temperature,
+        top_k=top_k,
+        use_kv_cache=use_kv_cache,
     )[0].tolist()
 
     continuation = generated[1:]

--- a/src/gpt/gpt.py
+++ b/src/gpt/gpt.py
@@ -7,6 +7,7 @@ from dataclasses import asdict, dataclass
 import torch
 from torch import Tensor, nn
 
+from .attention import LayerCache
 from .blocks import RMSNorm, TransformerBlock
 from .embeddings import GPTInputEmbedding
 
@@ -60,6 +61,25 @@ class GPT(nn.Module):
         x = self.final_norm(x)
         return self.lm_head(x)
 
+    def forward_with_cache(
+        self,
+        token_ids: Tensor,
+        cache: list[LayerCache | None] | None,
+        *,
+        position_offset: int,
+    ) -> tuple[Tensor, list[LayerCache]]:
+        x = self.embedding.embed_with_positions(token_ids, position_offset=position_offset)
+        next_cache: list[LayerCache] = []
+        if cache is None:
+            cache = [None] * len(self.blocks)
+
+        for block, layer_cache in zip(self.blocks, cache, strict=False):
+            x, updated_cache = block.forward_with_cache(x, cache=layer_cache)
+            next_cache.append(updated_cache)
+
+        x = self.final_norm(x)
+        return self.lm_head(x), next_cache
+
     @torch.no_grad()
     def generate(
         self,
@@ -67,10 +87,24 @@ class GPT(nn.Module):
         *,
         max_new_tokens: int,
         temperature: float = 1.0,
+        top_k: int | None = None,
+        use_kv_cache: bool = True,
     ) -> Tensor:
         if temperature <= 0:
             msg = "temperature must be positive"
             raise ValueError(msg)
+
+        if top_k is not None and top_k <= 0:
+            msg = "top_k must be positive when provided"
+            raise ValueError(msg)
+
+        if use_kv_cache:
+            return self.generate_with_cache(
+                token_ids,
+                max_new_tokens=max_new_tokens,
+                temperature=temperature,
+                top_k=top_k,
+            )
 
         generated = token_ids
         block_size = self.embedding.block_size
@@ -79,8 +113,62 @@ class GPT(nn.Module):
             idx_cond = generated[:, -block_size:]
             logits = self(idx_cond)
             next_token_logits = logits[:, -1, :] / temperature
+            if top_k is not None:
+                top_values, _ = torch.topk(
+                    next_token_logits, k=min(top_k, next_token_logits.size(-1))
+                )
+                threshold = top_values[:, [-1]]
+                next_token_logits = next_token_logits.masked_fill(
+                    next_token_logits < threshold, float("-inf")
+                )
             probs = torch.softmax(next_token_logits, dim=-1)
             next_token = torch.multinomial(probs, num_samples=1)
             generated = torch.cat((generated, next_token), dim=1)
+
+        return generated
+
+    @torch.no_grad()
+    def generate_with_cache(
+        self,
+        token_ids: Tensor,
+        *,
+        max_new_tokens: int,
+        temperature: float = 1.0,
+        top_k: int | None = None,
+    ) -> Tensor:
+        generated = token_ids
+        cache: list[LayerCache | None] = [None] * len(self.blocks)
+        logits: Tensor | None = None
+
+        for position in range(token_ids.size(1)):
+            current_token = token_ids[:, position : position + 1]
+            logits, cache = self.forward_with_cache(
+                current_token,
+                cache,
+                position_offset=position,
+            )
+
+        if logits is None:
+            msg = "token_ids must contain at least one token"
+            raise ValueError(msg)
+
+        for _ in range(max_new_tokens):
+            next_token_logits = logits[:, -1, :] / temperature
+            if top_k is not None:
+                top_values, _ = torch.topk(
+                    next_token_logits, k=min(top_k, next_token_logits.size(-1))
+                )
+                threshold = top_values[:, [-1]]
+                next_token_logits = next_token_logits.masked_fill(
+                    next_token_logits < threshold, float("-inf")
+                )
+            probs = torch.softmax(next_token_logits, dim=-1)
+            next_token = torch.multinomial(probs, num_samples=1)
+            generated = torch.cat((generated, next_token), dim=1)
+            logits, cache = self.forward_with_cache(
+                next_token,
+                cache,
+                position_offset=generated.size(1) - 1,
+            )
 
         return generated


### PR DESCRIPTION
## Summary

- add `top-k` sampling and an optional KV-cache generation path
- add lightweight validation metrics with loss and perplexity reporting
- expose generation/evaluation controls through the CLI while keeping the implementation split across inference and evaluation modules

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python - <<'PY'`
  - train a tiny model
  - save a checkpoint
  - generate with and without KV-cache using `top-k`
  - compute validation loss and perplexity
- `uv run python -m gpt train --num-steps 5 --log-interval 5 --block-size 16 --batch-size 16 --n-layer 2 --n-head 4 --n-embd 32 --tokenizer-kind bpe --bpe-vocab-size 64 --prompt a --max-new-tokens 8 --top-k 5 --checkpoint-out /tmp/gpt-issue13.pt`
- `uv run python -m gpt generate /tmp/gpt-issue13.pt --prompt a --max-new-tokens 8 --top-k 5`
- `uv run python -m gpt evaluate /tmp/gpt-issue13.pt --num-batches 2 --batch-size 8`

Closes #13
