### PR TITLE
feat: add rotary position embeddings

### DIFF
--- a/src/gpt/attention.py
+++ b/src/gpt/attention.py
@@ -7,6 +7,8 @@ import math
 import torch
 from torch import Tensor, nn
 
+from .rope import RotaryEmbedding
+
 LayerCache = tuple[Tensor, Tensor]
 
 
@@ -17,17 +19,18 @@ def causal_mask(sequence_length: int, device: torch.device) -> Tensor:
 class SingleHeadCausalSelfAttention(nn.Module):
     """A single masked self-attention head for decoder-only GPT."""
 
-    def __init__(self, *, n_embd: int) -> None:
+    def __init__(self, *, n_embd: int, use_rope: bool = False) -> None:
         super().__init__()
         self.n_embd = n_embd
         self.query = nn.Linear(n_embd, n_embd, bias=False)
         self.key = nn.Linear(n_embd, n_embd, bias=False)
         self.value = nn.Linear(n_embd, n_embd, bias=False)
+        self.rope = RotaryEmbedding(n_embd) if use_rope else None
 
     def forward(self, x: Tensor) -> Tensor:
         return self.inspect(x)["output"]
 
-    def inspect(self, x: Tensor) -> dict[str, Tensor]:
+    def inspect(self, x: Tensor, *, position_offset: int = 0) -> dict[str, Tensor]:
         if x.ndim != 3:
             msg = "x must have shape (batch_size, sequence_length, n_embd)"
             raise ValueError(msg)
@@ -39,6 +42,9 @@ class SingleHeadCausalSelfAttention(nn.Module):
         q = self.query(x)
         k = self.key(x)
         v = self.value(x)
+        if self.rope is not None:
+            q = self.rope.apply(q.unsqueeze(1), position_offset=position_offset).squeeze(1)
+            k = self.rope.apply(k.unsqueeze(1), position_offset=position_offset).squeeze(1)
         scale = 1.0 / math.sqrt(self.n_embd)
         scores = torch.matmul(q, k.transpose(-2, -1)) * scale
 
@@ -66,7 +72,7 @@ class SingleHeadCausalSelfAttention(nn.Module):
 class MultiHeadCausalSelfAttention(nn.Module):
     """A minimal multi-head masked self-attention module for decoder-only GPT."""
 
-    def __init__(self, *, n_embd: int, n_head: int) -> None:
+    def __init__(self, *, n_embd: int, n_head: int, use_rope: bool = False) -> None:
         super().__init__()
         if n_embd % n_head != 0:
             msg = "n_embd must be divisible by n_head"
@@ -79,6 +85,7 @@ class MultiHeadCausalSelfAttention(nn.Module):
         self.key = nn.Linear(n_embd, n_embd, bias=False)
         self.value = nn.Linear(n_embd, n_embd, bias=False)
         self.proj = nn.Linear(n_embd, n_embd, bias=False)
+        self.rope = RotaryEmbedding(self.head_dim) if use_rope else None
 
     def _split_heads(self, x: Tensor) -> Tensor:
         batch_size, sequence_length, _ = x.shape
@@ -90,13 +97,15 @@ class MultiHeadCausalSelfAttention(nn.Module):
         x = x.transpose(1, 2).contiguous()
         return x.view(batch_size, sequence_length, self.n_embd)
 
-    def forward(self, x: Tensor) -> Tensor:
-        return self.inspect(x)["output"]
+    def forward(self, x: Tensor, *, position_offset: int = 0) -> Tensor:
+        return self.inspect(x, position_offset=position_offset)["output"]
 
     def forward_with_cache(
         self,
         x: Tensor,
         cache: LayerCache | None = None,
+        *,
+        position_offset: int = 0,
     ) -> tuple[Tensor, LayerCache]:
         if x.ndim != 3:
             msg = "x must have shape (batch_size, sequence_length, n_embd)"
@@ -108,6 +117,9 @@ class MultiHeadCausalSelfAttention(nn.Module):
         q = self._split_heads(self.query(x))
         k_new = self._split_heads(self.key(x))
         v_new = self._split_heads(self.value(x))
+        if self.rope is not None:
+            q = self.rope.apply(q, position_offset=position_offset)
+            k_new = self.rope.apply(k_new, position_offset=position_offset)
 
         if cache is None:
             k_all = k_new
@@ -124,7 +136,7 @@ class MultiHeadCausalSelfAttention(nn.Module):
         merged = self._merge_heads(head_outputs)
         return self.proj(merged), (k_all, v_all)
 
-    def inspect(self, x: Tensor) -> dict[str, Tensor]:
+    def inspect(self, x: Tensor, *, position_offset: int = 0) -> dict[str, Tensor]:
         if x.ndim != 3:
             msg = "x must have shape (batch_size, sequence_length, n_embd)"
             raise ValueError(msg)
@@ -136,6 +148,9 @@ class MultiHeadCausalSelfAttention(nn.Module):
         q = self._split_heads(self.query(x))
         k = self._split_heads(self.key(x))
         v = self._split_heads(self.value(x))
+        if self.rope is not None:
+            q = self.rope.apply(q, position_offset=position_offset)
+            k = self.rope.apply(k, position_offset=position_offset)
 
         scale = 1.0 / math.sqrt(self.head_dim)
         scores = torch.matmul(q, k.transpose(-2, -1)) * scale

--- a/src/gpt/blocks.py
+++ b/src/gpt/blocks.py
@@ -39,18 +39,29 @@ class FeedForward(nn.Module):
 class TransformerBlock(nn.Module):
     """A pre-norm decoder block with attention and feed-forward sublayers."""
 
-    def __init__(self, *, n_embd: int, n_head: int, expansion_factor: int = 4) -> None:
+    def __init__(
+        self,
+        *,
+        n_embd: int,
+        n_head: int,
+        expansion_factor: int = 4,
+        positional_strategy: str = "learned",
+    ) -> None:
         super().__init__()
         self.attention_norm = RMSNorm(n_embd)
-        self.attention = MultiHeadCausalSelfAttention(n_embd=n_embd, n_head=n_head)
+        self.attention = MultiHeadCausalSelfAttention(
+            n_embd=n_embd,
+            n_head=n_head,
+            use_rope=positional_strategy == "rope",
+        )
         self.feed_forward_norm = RMSNorm(n_embd)
         self.feed_forward = FeedForward(
             n_embd=n_embd,
             expansion_factor=expansion_factor,
         )
 
-    def forward(self, x: Tensor) -> Tensor:
-        x = x + self.attention(self.attention_norm(x))
+    def forward(self, x: Tensor, *, position_offset: int = 0) -> Tensor:
+        x = x + self.attention(self.attention_norm(x), position_offset=position_offset)
         x = x + self.feed_forward(self.feed_forward_norm(x))
         return x
 
@@ -58,10 +69,13 @@ class TransformerBlock(nn.Module):
         self,
         x: Tensor,
         cache: LayerCache | None = None,
+        *,
+        position_offset: int = 0,
     ) -> tuple[Tensor, LayerCache]:
         attention_out, next_cache = self.attention.forward_with_cache(
             self.attention_norm(x),
             cache=cache,
+            position_offset=position_offset,
         )
         x = x + attention_out
         x = x + self.feed_forward(self.feed_forward_norm(x))

--- a/src/gpt/cli.py
+++ b/src/gpt/cli.py
@@ -37,6 +37,11 @@ def build_parser() -> ArgumentParser:
     train_parser.add_argument("--n-layer", type=int, default=2)
     train_parser.add_argument("--n-head", type=int, default=4)
     train_parser.add_argument("--n-embd", type=int, default=64)
+    train_parser.add_argument(
+        "--positional-strategy",
+        choices=["learned", "rope"],
+        default="learned",
+    )
     train_parser.add_argument("--learning-rate", type=float, default=1e-3)
     train_parser.add_argument("--num-steps", type=int, default=200)
     train_parser.add_argument("--log-interval", type=int, default=20)
@@ -86,6 +91,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             n_layer=args.n_layer,
             n_head=args.n_head,
             n_embd=args.n_embd,
+            positional_strategy=args.positional_strategy,
             learning_rate=args.learning_rate,
             num_steps=args.num_steps,
             log_interval=args.log_interval,

--- a/src/gpt/embeddings.py
+++ b/src/gpt/embeddings.py
@@ -9,12 +9,27 @@ from torch import Tensor, nn
 class GPTInputEmbedding(nn.Module):
     """Combine token embeddings and learned positional embeddings."""
 
-    def __init__(self, *, vocab_size: int, block_size: int, n_embd: int) -> None:
+    def __init__(
+        self,
+        *,
+        vocab_size: int,
+        block_size: int,
+        n_embd: int,
+        positional_strategy: str = "learned",
+    ) -> None:
         super().__init__()
+        if positional_strategy not in {"learned", "rope"}:
+            msg = "positional_strategy must be 'learned' or 'rope'"
+            raise ValueError(msg)
+
         self.block_size = block_size
         self.n_embd = n_embd
+        self.positional_strategy = positional_strategy
         self.token_embedding = nn.Embedding(vocab_size, n_embd)
-        self.position_embedding = nn.Embedding(block_size, n_embd)
+        if positional_strategy == "learned":
+            self.position_embedding: nn.Embedding | None = nn.Embedding(block_size, n_embd)
+        else:
+            self.position_embedding = None
 
     def embed_with_positions(self, token_ids: Tensor, *, position_offset: int = 0) -> Tensor:
         if token_ids.ndim != 2:
@@ -33,6 +48,9 @@ class GPTInputEmbedding(nn.Module):
             device=token_ids.device,
         )
         token_embeddings = self.token_embedding(token_ids)
+        if self.position_embedding is None:
+            return token_embeddings
+
         position_embeddings = self.position_embedding(position_ids).unsqueeze(0)
         return token_embeddings + position_embeddings
 

--- a/src/gpt/gpt.py
+++ b/src/gpt/gpt.py
@@ -20,6 +20,7 @@ class GPTConfig:
     n_head: int
     n_embd: int
     expansion_factor: int = 4
+    positional_strategy: str = "learned"
 
     def to_dict(self) -> dict[str, int]:
         return asdict(self)
@@ -42,12 +43,14 @@ class GPT(nn.Module):
             vocab_size=config.vocab_size,
             block_size=config.block_size,
             n_embd=config.n_embd,
+            positional_strategy=config.positional_strategy,
         )
         self.blocks = nn.ModuleList(
             TransformerBlock(
                 n_embd=config.n_embd,
                 n_head=config.n_head,
                 expansion_factor=config.expansion_factor,
+                positional_strategy=config.positional_strategy,
             )
             for _ in range(config.n_layer)
         )
@@ -74,7 +77,11 @@ class GPT(nn.Module):
             cache = [None] * len(self.blocks)
 
         for block, layer_cache in zip(self.blocks, cache, strict=False):
-            x, updated_cache = block.forward_with_cache(x, cache=layer_cache)
+            x, updated_cache = block.forward_with_cache(
+                x,
+                cache=layer_cache,
+                position_offset=position_offset,
+            )
             next_cache.append(updated_cache)
 
         x = self.final_norm(x)

--- a/src/gpt/rope.py
+++ b/src/gpt/rope.py
@@ -1,0 +1,58 @@
+"""Rotary position embedding helpers."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor, nn
+
+
+def rotate_half(x: Tensor) -> Tensor:
+    """Rotate pairs of features by 90 degrees."""
+    x_even = x[..., ::2]
+    x_odd = x[..., 1::2]
+    rotated = torch.stack((-x_odd, x_even), dim=-1)
+    return rotated.flatten(start_dim=-2)
+
+
+class RotaryEmbedding(nn.Module):
+    """Apply deterministic rotary position encoding to query/key tensors."""
+
+    def __init__(self, dim: int, *, base: float = 10_000.0) -> None:
+        super().__init__()
+        if dim % 2 != 0:
+            msg = "RoPE head dimension must be even"
+            raise ValueError(msg)
+
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2).float() / dim))
+        self.dim = dim
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def angles(
+        self,
+        sequence_length: int,
+        *,
+        device: torch.device,
+        position_offset: int = 0,
+    ) -> tuple[Tensor, Tensor]:
+        positions = torch.arange(
+            position_offset,
+            position_offset + sequence_length,
+            device=device,
+            dtype=self.inv_freq.dtype,
+        )
+        angles = torch.outer(positions, self.inv_freq.to(device))
+        cos = torch.repeat_interleave(torch.cos(angles), repeats=2, dim=-1)
+        sin = torch.repeat_interleave(torch.sin(angles), repeats=2, dim=-1)
+        return cos.unsqueeze(0).unsqueeze(0), sin.unsqueeze(0).unsqueeze(0)
+
+    def apply(self, x: Tensor, *, position_offset: int = 0) -> Tensor:
+        if x.size(-1) != self.dim:
+            msg = f"last dimension must be rotary dim ({self.dim})"
+            raise ValueError(msg)
+
+        cos, sin = self.angles(
+            x.size(-2),
+            device=x.device,
+            position_offset=position_offset,
+        )
+        return (x * cos) + (rotate_half(x) * sin)

--- a/src/gpt/training.py
+++ b/src/gpt/training.py
@@ -26,6 +26,7 @@ class TrainingConfig:
     log_interval: int = 20
     tokenizer_kind: str = "bpe"
     bpe_vocab_size: int = 128
+    positional_strategy: str = "learned"
 
     def model_config(self, vocab_size: int) -> GPTConfig:
         return GPTConfig(
@@ -34,6 +35,7 @@ class TrainingConfig:
             n_layer=self.n_layer,
             n_head=self.n_head,
             n_embd=self.n_embd,
+            positional_strategy=self.positional_strategy,
         )
 
 


### PR DESCRIPTION
## Summary

- add rotary position embedding support in attention
- keep learned positional embeddings available for comparison
- make positional strategy configurable via training CLI

## Testing

- uv run ruff check .
- uv run ruff format --check .
- uv run python -m gpt train --num-steps 5 --log-interval 5 --block-size 16 --batch-size 8 --n-layer 2 --n-head 4 --n-embd 32 --tokenizer-kind bpe --bpe-vocab-size 64 --positional-strategy rope --prompt a --max-new-tokens 8 --checkpoint-out /tmp/gpt-rope.pt
- uv run python -m gpt generate /tmp/gpt-rope.pt --prompt a --max-new-tokens 8
- uv run python -m gpt evaluate /tmp/gpt-rope.pt --num-batches 2 --batch-size 8
- uv run python -m gpt train --num-steps 1 --log-interval 1 --block-size 16 --batch-size 8 --n-layer 2 --n-head 4 --n-embd 32 --tokenizer-kind bpe --bpe-vocab-size 64 --positional-strategy learned --prompt a --max-new-tokens 4

Closes #17

Stacked on #26.
