### PR TITLE
feat: add configurable swiglu mlp

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,15 @@ uv run python -m gpt train \
 
 The command prints training loss and a sampled continuation at the end.
 
+To switch the MLP block to SwiGLU instead of the baseline GELU feed-forward, add
+`--mlp-variant swiglu`.
+
 ## Current scope
 
 - character-level tokenizer
 - next-token batch sampling
 - learned token and positional embeddings
 - single-head and multi-head causal self-attention
-- feed-forward network, residual connections, and RMSNorm
+- configurable GELU or SwiGLU feed-forward network, residual connections, and RMSNorm
 - decoder-only GPT model with LM head
 - minimal training loop and autoregressive generation

--- a/src/gpt/blocks.py
+++ b/src/gpt/blocks.py
@@ -25,15 +25,39 @@ class RMSNorm(nn.Module):
 class FeedForward(nn.Module):
     """A position-wise feed-forward network."""
 
-    def __init__(self, *, n_embd: int, expansion_factor: int = 4) -> None:
+    def __init__(
+        self,
+        *,
+        n_embd: int,
+        expansion_factor: int = 4,
+        mlp_variant: str = "gelu",
+    ) -> None:
         super().__init__()
         hidden_dim = expansion_factor * n_embd
-        self.in_proj = nn.Linear(n_embd, hidden_dim, bias=False)
-        self.activation = nn.GELU()
+        self.mlp_variant = mlp_variant
+
+        if mlp_variant == "gelu":
+            self.in_proj = nn.Linear(n_embd, hidden_dim, bias=False)
+            self.activation = nn.GELU()
+            self.gate_proj: nn.Linear | None = None
+        elif mlp_variant == "swiglu":
+            self.in_proj = nn.Linear(n_embd, hidden_dim, bias=False)
+            self.activation = nn.SiLU()
+            self.gate_proj = nn.Linear(n_embd, hidden_dim, bias=False)
+        else:
+            msg = f"unsupported mlp_variant: {mlp_variant}"
+            raise ValueError(msg)
+
         self.out_proj = nn.Linear(hidden_dim, n_embd, bias=False)
 
     def forward(self, x: Tensor) -> Tensor:
-        return self.out_proj(self.activation(self.in_proj(x)))
+        projected = self.in_proj(x)
+        if self.mlp_variant == "swiglu":
+            assert self.gate_proj is not None
+            projected = self.activation(projected) * self.gate_proj(x)
+        else:
+            projected = self.activation(projected)
+        return self.out_proj(projected)
 
 
 class TransformerBlock(nn.Module):
@@ -46,6 +70,7 @@ class TransformerBlock(nn.Module):
         n_head: int,
         expansion_factor: int = 4,
         positional_strategy: str = "learned",
+        mlp_variant: str = "gelu",
     ) -> None:
         super().__init__()
         self.attention_norm = RMSNorm(n_embd)
@@ -58,6 +83,7 @@ class TransformerBlock(nn.Module):
         self.feed_forward = FeedForward(
             n_embd=n_embd,
             expansion_factor=expansion_factor,
+            mlp_variant=mlp_variant,
         )
 
     def forward(self, x: Tensor, *, position_offset: int = 0) -> Tensor:

--- a/src/gpt/cli.py
+++ b/src/gpt/cli.py
@@ -42,6 +42,11 @@ def build_parser() -> ArgumentParser:
         choices=["learned", "rope"],
         default="learned",
     )
+    train_parser.add_argument(
+        "--mlp-variant",
+        choices=["gelu", "swiglu"],
+        default="gelu",
+    )
     train_parser.add_argument("--learning-rate", type=float, default=1e-3)
     train_parser.add_argument("--num-steps", type=int, default=200)
     train_parser.add_argument("--log-interval", type=int, default=20)
@@ -92,6 +97,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             n_head=args.n_head,
             n_embd=args.n_embd,
             positional_strategy=args.positional_strategy,
+            mlp_variant=args.mlp_variant,
             learning_rate=args.learning_rate,
             num_steps=args.num_steps,
             log_interval=args.log_interval,

--- a/src/gpt/gpt.py
+++ b/src/gpt/gpt.py
@@ -21,12 +21,13 @@ class GPTConfig:
     n_embd: int
     expansion_factor: int = 4
     positional_strategy: str = "learned"
+    mlp_variant: str = "gelu"
 
-    def to_dict(self) -> dict[str, int]:
+    def to_dict(self) -> dict[str, int | str]:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, payload: dict[str, int]) -> GPTConfig:
+    def from_dict(cls, payload: dict[str, int | str]) -> GPTConfig:
         return cls(**payload)
 
 
@@ -51,6 +52,7 @@ class GPT(nn.Module):
                 n_head=config.n_head,
                 expansion_factor=config.expansion_factor,
                 positional_strategy=config.positional_strategy,
+                mlp_variant=config.mlp_variant,
             )
             for _ in range(config.n_layer)
         )

--- a/src/gpt/training.py
+++ b/src/gpt/training.py
@@ -27,6 +27,7 @@ class TrainingConfig:
     tokenizer_kind: str = "bpe"
     bpe_vocab_size: int = 128
     positional_strategy: str = "learned"
+    mlp_variant: str = "gelu"
 
     def model_config(self, vocab_size: int) -> GPTConfig:
         return GPTConfig(
@@ -36,6 +37,7 @@ class TrainingConfig:
             n_head=self.n_head,
             n_embd=self.n_embd,
             positional_strategy=self.positional_strategy,
+            mlp_variant=self.mlp_variant,
         )
 
 


### PR DESCRIPTION
## 概要

GPT の MLP ブロックに `swiglu` を追加し、従来の `gelu` ベース FFN と設定で切り替えられるようにしました。

close #18

## 変更内容

- `FeedForward` に `mlp_variant` を追加して `gelu` / `swiglu` を切り替え可能に変更
- `GPTConfig` と `TrainingConfig` に `mlp_variant` を追加
- CLI の `train` コマンドに `--mlp-variant` を追加
- README に SwiGLU の利用方法を追記

## 確認内容

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m gpt --help`
- `uv run python -c "from gpt.gpt import GPT, GPTConfig; import torch; model = GPT(GPTConfig(vocab_size=32, block_size=8, n_layer=2, n_head=2, n_embd=16, mlp_variant='swiglu')); x = torch.randint(0, 32, (2, 8)); print(model(x).shape)"`